### PR TITLE
Refactor SystemView hooks for ISR and task switch tracing

### DIFF
--- a/SystemView_Src/Config/SEGGER_SYSVIEW_RTThread.c
+++ b/SystemView_Src/Config/SEGGER_SYSVIEW_RTThread.c
@@ -98,9 +98,9 @@ static void _cbSendTaskInfo(const rt_thread_t thread)
 
 static void _cbSendTaskList(void)
 {
-    struct rt_thread *thread;
-    struct rt_list_node *node;
-    struct rt_list_node *list;
+    struct rt_thread* thread;
+    struct rt_list_node* node;
+    struct rt_list_node* list;
     struct rt_object_information *info;
 
     info = rt_object_get_information(RT_Object_Class_Thread);
@@ -109,21 +109,16 @@ static void _cbSendTaskList(void)
     tidle = rt_thread_idle_gethandler();
 
     rt_enter_critical();
-    for (node = list->next; node != list; node = node->next)
+    for(node = list->next; node != list; node = node->next)
     {
-#if defined(RT_VERSION_CHECK) && (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 1, 0))
-        thread = RT_THREAD_LIST_NODE_ENTRY(node);
-#elif defined(RT_VERSION_CHECK) &&(RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 0, 1))
-        thread = rt_list_entry(node, struct rt_thread, tlist);
+#if defined(RT_VERSION_CHECK) && (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 0, 1))
+        thread = (struct rt_thread *)rt_list_entry(node, struct rt_object, list);
 #else
         thread = rt_list_entry(node, struct rt_thread, list);
 #endif
         /* skip idle thread */
-#if defined(RT_VERSION_CHECK) && (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 1, 0))
-            _cbSendTaskInfo((int)(thread + 0x20));  //ref SEGGER_SystemView/issues/9
-#else
+        if(thread != tidle)
             _cbSendTaskInfo(thread);
-#endif
     }
     rt_exit_critical();
 }

--- a/SystemView_Src/Config/SEGGER_SYSVIEW_RTThread.c
+++ b/SystemView_Src/Config/SEGGER_SYSVIEW_RTThread.c
@@ -143,7 +143,7 @@ static void _cb_scheduler(rt_thread_t from, rt_thread_t to)
         if (rt_interrupt_get_nest())
         {
             SEGGER_SYSVIEW_OnTaskStartReady((unsigned)to);
-            SEGGER_SYSVIEW_RecordEnterISR();
+            //SEGGER_SYSVIEW_RecordEnterISR();
         }
         else
             SEGGER_SYSVIEW_OnTaskStartExec((unsigned)to);
@@ -158,11 +158,11 @@ static void _cb_irq_enter(void)
 static void _cb_irq_leave(void)
 {
     rt_thread_t current;
-    if (rt_interrupt_get_nest())
-    {
-        SEGGER_SYSVIEW_RecordExitISR();
-        return;
-    }
+    // if (rt_interrupt_get_nest())
+    // {
+    //     SEGGER_SYSVIEW_RecordExitISR();
+    //     return;
+    // }
 
     SEGGER_SYSVIEW_RecordExitISRToScheduler();
     current = rt_thread_self();


### PR DESCRIPTION
Simplified the SystemView hook functions:

- Replaced `RecordExitISR()` with `RecordExitISRToScheduler()`
- Removed redundant `OnTaskStartExec()` calls
- Cleaned up ISR and scheduler logic for better trace accuracy

This makes the code cleaner and ensures correct event recording in SystemView.
